### PR TITLE
Use default `cacheDirectory`

### DIFF
--- a/packages/build/src/create-webpack-config.ts
+++ b/packages/build/src/create-webpack-config.ts
@@ -7,9 +7,7 @@ const createBabelLoader = (isDevelopment: boolean) => ({
   loader: 'babel-loader',
   options: {
     cacheCompression: false,
-    cacheDirectory: isDevelopment
-      ? join(constants.build.cacheDirectoryName, 'babel-loader')
-      : false,
+    cacheDirectory: isDevelopment,
     plugins: [
       '@babel/plugin-proposal-object-rest-spread',
       [
@@ -29,24 +27,14 @@ const createBabelLoader = (isDevelopment: boolean) => ({
   }
 })
 
-const webpackCache: webpack.Configuration['cache'] = {
-  cacheDirectory: resolve(
-    process.cwd(),
-    constants.build.cacheDirectoryName,
-    'webpack'
-  ),
-  type: 'filesystem'
-}
-
 export function createWebpackConfig(
   entry: webpack.Entry,
   isDevelopment: boolean
 ): webpack.Configuration {
   const mode = isDevelopment ? 'development' : 'production'
   const babelLoader = createBabelLoader(isDevelopment)
-
   return {
-    cache: isDevelopment ? webpackCache : false,
+    cache: isDevelopment ? { type: 'filesystem' } : false,
     devtool: isDevelopment ? 'inline-cheap-module-source-map' : false,
     entry,
     mode,

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,7 +1,6 @@
 export const constants = {
   apiVersion: '1.0.0',
   build: {
-    cacheDirectoryName: 'build/cache',
     directoryName: 'build',
     manifestFilePath: 'manifest.json',
     pluginCodeFilePath: 'build/main.js',


### PR DESCRIPTION
Using the default cache directory for both Webpack and `babel-loader` seems to give the same build speed up for me as setting a custom cache directory.

- https://webpack.js.org/configuration/other-options/#cachecachedirectory
- https://webpack.js.org/loaders/babel-loader/#options